### PR TITLE
fix: resolve lint issues in test files

### DIFF
--- a/test/capture-element-image.spec.ts
+++ b/test/capture-element-image.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Capture Element Image Tool', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,13 +10,13 @@ test.describe('Capture Element Image Tool', () => {
     const snapshotResult = await page.evaluate(() => {
       return window.A11yCap.snapshotForAI(document.body);
     });
-    
+
     expect(snapshotResult).toContain('button "Click me (0)"');
     expect(snapshotResult).toContain('[ref=e5]');
 
     // Capture image of the button
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['capture_element_image'].execute({
+      return window.A11yCap.toolHandlers.capture_element_image.execute({
         id: 'test-capture',
         type: 'capture_element_image',
         payload: {
@@ -25,8 +25,8 @@ test.describe('Capture Element Image Tool', () => {
           captureSnapshot: false,
           quality: 0.8,
           backgroundColor: '#ffffff',
-          cacheBust: false
-        }
+          cacheBust: false,
+        },
       });
     });
 
@@ -40,7 +40,7 @@ test.describe('Capture Element Image Tool', () => {
 
   test('should handle non-existent element ref', async ({ page }) => {
     const resultPromise = page.evaluate(() => {
-      return window.A11yCap.toolHandlers['capture_element_image'].execute({
+      return window.A11yCap.toolHandlers.capture_element_image.execute({
         id: 'test-capture',
         type: 'capture_element_image',
         payload: {
@@ -48,15 +48,19 @@ test.describe('Capture Element Image Tool', () => {
           ref: 'e999',
           captureSnapshot: false,
           quality: 0.8,
-          cacheBust: false
-        }
+          cacheBust: false,
+        },
       });
     });
 
-    await expect(resultPromise).rejects.toThrow('Element with ref "e999" not found');
+    await expect(resultPromise).rejects.toThrow(
+      'Element with ref "e999" not found'
+    );
   });
 
-  test('should handle quality parameter (PNG ignores quality)', async ({ page }) => {
+  test('should handle quality parameter (PNG ignores quality)', async ({
+    page,
+  }) => {
     // Get a valid element ref first
     await page.evaluate(() => {
       return window.A11yCap.snapshotForAI(document.body);
@@ -64,7 +68,7 @@ test.describe('Capture Element Image Tool', () => {
 
     // Test with quality setting (PNG ignores this but should not error)
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['capture_element_image'].execute({
+      return window.A11yCap.toolHandlers.capture_element_image.execute({
         id: 'test-capture',
         type: 'capture_element_image',
         payload: {
@@ -72,8 +76,8 @@ test.describe('Capture Element Image Tool', () => {
           ref: 'e5',
           captureSnapshot: false,
           quality: 0.5,
-          cacheBust: false
-        }
+          cacheBust: false,
+        },
       });
     });
 
@@ -88,7 +92,7 @@ test.describe('Capture Element Image Tool', () => {
     });
 
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['capture_element_image'].execute({
+      return window.A11yCap.toolHandlers.capture_element_image.execute({
         id: 'test-capture',
         type: 'capture_element_image',
         payload: {
@@ -97,8 +101,8 @@ test.describe('Capture Element Image Tool', () => {
           captureSnapshot: false,
           quality: 0.8,
           backgroundColor: '#ff0000', // Red background
-          cacheBust: false
-        }
+          cacheBust: false,
+        },
       });
     });
 
@@ -113,7 +117,7 @@ test.describe('Capture Element Image Tool', () => {
     });
 
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['capture_element_image'].execute({
+      return window.A11yCap.toolHandlers.capture_element_image.execute({
         id: 'test-capture',
         type: 'capture_element_image',
         payload: {
@@ -123,8 +127,8 @@ test.describe('Capture Element Image Tool', () => {
           quality: 0.8,
           width: 200,
           height: 100,
-          cacheBust: false
-        }
+          cacheBust: false,
+        },
       });
     });
 

--- a/test/click-ref.spec.ts
+++ b/test/click-ref.spec.ts
@@ -7,7 +7,10 @@ test.describe('Click Ref Functionality', () => {
 
     // Take a snapshot to generate refs
     const snapshot = await page.evaluate(() => {
-      return window.A11yCap.snapshot(document.body, { mode: 'ai', enableReact: true });
+      return window.A11yCap.snapshot(document.body, {
+        mode: 'ai',
+        enableReact: true,
+      });
     });
 
     console.log('Initial snapshot:', snapshot);
@@ -23,7 +26,7 @@ test.describe('Click Ref Functionality', () => {
     const initialText = await page.evaluate(() => {
       return document.getElementById('test-button')?.textContent;
     });
-    
+
     console.log('Initial button text:', initialText);
 
     // Use clickRef function to click the button
@@ -37,7 +40,7 @@ test.describe('Click Ref Functionality', () => {
     const newText = await page.evaluate(() => {
       return document.getElementById('test-button')?.textContent;
     });
-    
+
     console.log('New button text:', newText);
 
     // The counter should have incremented
@@ -59,23 +62,23 @@ test.describe('Click Ref Functionality', () => {
       // Find the button ref from the snapshot
       const buttons = document.querySelectorAll('button');
       let buttonRef = '';
-      
+
       for (const button of buttons) {
         if ((button as any)._ariaRef?.ref) {
           buttonRef = (button as any)._ariaRef.ref;
           break;
         }
       }
-      
+
       if (!buttonRef) return null;
-      
+
       // Use findElementByRef to locate it
       const found = window.A11yCap.findElementByRef(buttonRef);
       return {
         found: !!found,
         isButton: found?.tagName === 'BUTTON',
         hasId: found?.id === 'test-button',
-        ref: buttonRef
+        ref: buttonRef,
       };
     });
 
@@ -83,7 +86,7 @@ test.describe('Click Ref Functionality', () => {
     expect(foundElement!.found).toBe(true);
     expect(foundElement!.isButton).toBe(true);
     expect(foundElement!.hasId).toBe(true);
-    
+
     console.log('Found element with ref:', foundElement!.ref);
   });
 

--- a/test/console-logs.spec.ts
+++ b/test/console-logs.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Console logs buffering', () => {
   test.beforeEach(async ({ page }) => {
@@ -24,13 +24,13 @@ test.describe('Console logs buffering', () => {
       return window.A11yCap.toolHandlers.get_console_logs.execute({
         id: 'test-1',
         type: 'get_console_logs',
-        payload: {}
+        payload: {},
       });
     });
 
     expect(typeof logs).toBe('string');
     expect(logs).toContain('Console logs');
-    
+
     // Check that we have our test messages in the formatted output
     expect(logs.includes('Test log message')).toBe(true);
     expect(logs.includes('Test warning')).toBe(true);
@@ -54,7 +54,7 @@ test.describe('Console logs buffering', () => {
       return window.A11yCap.toolHandlers.get_console_logs.execute({
         id: 'test-2',
         type: 'get_console_logs',
-        payload: { level: 'error' }
+        payload: { level: 'error' },
       });
     });
 
@@ -71,7 +71,7 @@ test.describe('Console logs buffering', () => {
       return window.A11yCap.toolHandlers.get_console_logs.execute({
         id: 'test-3',
         type: 'get_console_logs',
-        payload: { level: 'warn' }
+        payload: { level: 'warn' },
       });
     });
 
@@ -99,20 +99,22 @@ test.describe('Console logs buffering', () => {
       return window.A11yCap.toolHandlers.get_console_logs.execute({
         id: 'test-4',
         type: 'get_console_logs',
-        payload: { limit: 3 }
+        payload: { limit: 3 },
       });
     });
 
     expect(typeof limitedLogs).toBe('string');
     expect(limitedLogs).toContain('Console logs');
     // Count the number of log entries in the formatted output
-    const logLines = limitedLogs.split('\n').filter(line => line.includes('LOG '));
+    const logLines = limitedLogs
+      .split('\n')
+      .filter((line) => line.includes('LOG '));
     expect(logLines.length).toBeLessThanOrEqual(3);
   });
 
   test('should filter console logs by timestamp', async ({ page }) => {
     const startTime = Date.now();
-    
+
     // Generate a message before timestamp
     await page.evaluate(() => {
       console.log('Before timestamp message');
@@ -135,24 +137,26 @@ test.describe('Console logs buffering', () => {
       return window.A11yCap.toolHandlers.get_console_logs.execute({
         id: 'test-5',
         type: 'get_console_logs',
-        payload: { since }
+        payload: { since },
       });
     }, filterTime);
 
     expect(typeof recentLogs).toBe('string');
     expect(recentLogs).toContain('Console logs');
-    
+
     // Should include the "after" message but not the "before" message
     expect(recentLogs).toContain('After timestamp message');
     expect(recentLogs).not.toContain('Before timestamp message');
   });
 
-  test('should handle console messages with complex objects', async ({ page }) => {
+  test('should handle console messages with complex objects', async ({
+    page,
+  }) => {
     await page.evaluate(() => {
-      const complexObj = { 
-        nested: { value: 42 }, 
+      const complexObj = {
+        nested: { value: 42 },
         array: [1, 2, 3],
-        func: function() { return 'test'; }
+        func: () => 'test',
       };
       console.log('Complex object:', complexObj);
       console.error(new Error('Test error with stack'));
@@ -165,26 +169,28 @@ test.describe('Console logs buffering', () => {
       return window.A11yCap.toolHandlers.get_console_logs.execute({
         id: 'test-6',
         type: 'get_console_logs',
-        payload: {}
+        payload: {},
       });
     });
 
     expect(typeof logs).toBe('string');
     expect(logs).toContain('Console logs');
-    
+
     // Should have formatted the complex object and error
     expect(logs).toContain('Complex object:');
     expect(logs).toContain('Error: Test error with stack');
   });
 
-  test('should not interfere with original console behavior', async ({ page }) => {
+  test('should not interfere with original console behavior', async ({
+    page,
+  }) => {
     // Check that console methods still work normally
     const consoleCalls: any[] = [];
-    
-    page.on('console', msg => {
+
+    page.on('console', (msg) => {
       consoleCalls.push({
         type: msg.type(),
-        text: msg.text()
+        text: msg.text(),
       });
     });
 
@@ -197,8 +203,12 @@ test.describe('Console logs buffering', () => {
 
     // Original console should still work
     expect(consoleCalls.length).toBeGreaterThanOrEqual(2);
-    expect(consoleCalls.some(call => call.text.includes('Original console test'))).toBe(true);
-    expect(consoleCalls.some(call => call.text.includes('Original warning test'))).toBe(true);
+    expect(
+      consoleCalls.some((call) => call.text.includes('Original console test'))
+    ).toBe(true);
+    expect(
+      consoleCalls.some((call) => call.text.includes('Original warning test'))
+    ).toBe(true);
 
     // And buffered logs should also be available
     const bufferedLogs = await page.evaluate(() => {
@@ -206,7 +216,7 @@ test.describe('Console logs buffering', () => {
       return window.A11yCap.toolHandlers.get_console_logs.execute({
         id: 'test-7',
         type: 'get_console_logs',
-        payload: {}
+        payload: {},
       });
     });
 

--- a/test/debug-console.spec.ts
+++ b/test/debug-console.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Debug console logs setup', () => {
   test('should show what is available in window.A11yCap', async ({ page }) => {
@@ -9,12 +9,21 @@ test.describe('Debug console logs setup', () => {
     const a11yCapKeys = await page.evaluate(() => {
       return {
         exists: typeof window.A11yCap !== 'undefined',
-        keys: typeof window.A11yCap !== 'undefined' ? Object.keys(window.A11yCap) : [],
-        toolHandlers: typeof window.A11yCap !== 'undefined' && window.A11yCap.toolHandlers ? Object.keys(window.A11yCap.toolHandlers) : null,
+        keys:
+          typeof window.A11yCap !== 'undefined'
+            ? Object.keys(window.A11yCap)
+            : [],
+        toolHandlers:
+          typeof window.A11yCap !== 'undefined' && window.A11yCap.toolHandlers
+            ? Object.keys(window.A11yCap.toolHandlers)
+            : null,
         consoleOriginal: typeof console.log === 'function',
-        consoleModified: console.log.toString().includes('bufferConsoleMessage') || console.log.toString().length > 100,
+        consoleModified:
+          console.log.toString().includes('bufferConsoleMessage') ||
+          console.log.toString().length > 100,
         consoleToString: console.log.toString(),
-        hasOriginalConsole: typeof (window as any).__a11ycap_original_console !== 'undefined'
+        hasOriginalConsole:
+          typeof (window as any).__a11ycap_original_console !== 'undefined',
       };
     });
 
@@ -35,14 +44,14 @@ test.describe('Debug console logs setup', () => {
           hasAddEvent: typeof addEvent === 'function',
           hasGetEvents: typeof getEvents === 'function',
           hasGetBufferStats: typeof getBufferStats === 'function',
-          error: null
+          error: null,
         };
       } catch (error) {
         return {
           hasAddEvent: false,
           hasGetEvents: false,
           hasGetBufferStats: false,
-          error: error.message
+          error: error.message,
         };
       }
     });
@@ -63,7 +72,7 @@ test.describe('Debug console logs setup', () => {
           level: 'log',
           args: ['Manual test message'],
           timestamp: Date.now(),
-          url: window.location.href
+          url: window.location.href,
         };
 
         // Try to add it to buffer - we need to import the functions
@@ -71,12 +80,12 @@ test.describe('Debug console logs setup', () => {
         return {
           windowKeys: Object.keys(window),
           a11yCapAvailable: typeof (window as any).A11yCap !== 'undefined',
-          testEvent
+          testEvent,
         };
       } catch (error) {
         return {
           error: error.message,
-          stack: error.stack
+          stack: error.stack,
         };
       }
     });

--- a/test/debug-picked-elements.spec.ts
+++ b/test/debug-picked-elements.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Debug Picked Elements Tool', () => {
   test.beforeEach(async ({ page }) => {
@@ -7,12 +7,14 @@ test.describe('Debug Picked Elements Tool', () => {
     await page.waitForFunction(() => window.A11yCap);
   });
 
-  test('should manually add and retrieve picked element event', async ({ page }) => {
+  test('should manually add and retrieve picked element event', async ({
+    page,
+  }) => {
     // Manually add a picked element event and test if the tool can retrieve it
     const result = await page.evaluate(async () => {
       // Get current page UUID
       const pageUUID = (window as any)._a11yCapPageUUID;
-      
+
       // Manually add an element_picked event
       window.A11yCap.addEvent({
         type: 'element_picked',
@@ -24,30 +26,30 @@ test.describe('Debug Picked Elements Tool', () => {
           selector: 'button#test-button',
           textContent: 'Click me (0)',
           tagName: 'button',
-          snapshot: 'test snapshot'
-        }
+          snapshot: 'test snapshot',
+        },
       });
-      
+
       // Try to retrieve it with the tool
       const toolHandlers = window.A11yCap.toolHandlers;
       const getPickedElementsTool = toolHandlers.get_picked_elements;
-      
+
       const toolResult = await getPickedElementsTool.execute({
         id: 'test-debug',
         type: 'get_picked_elements',
-        payload: {}
+        payload: {},
       });
-      
+
       return {
         pageUUID,
         currentUrl: window.location.href,
         toolResult,
-        allEvents: window.A11yCap.getEvents().length
+        allEvents: window.A11yCap.getEvents().length,
       };
     });
 
     console.log('Debug result:', result);
-    
+
     expect(result.pageUUID).toBeDefined();
     expect(result.toolResult.totalPicked).toBe(1);
     expect(result.toolResult.elements.length).toBe(1);

--- a/test/debug-react.spec.ts
+++ b/test/debug-react.spec.ts
@@ -4,7 +4,9 @@ import { test } from '@playwright/test';
 test('debug react component names', async ({ page }) => {
   await page.goto('http://localhost:14652/');
   await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-  await page.waitForFunction(() => (window as any).reactDevToolsReady, { timeout: 5000 });
+  await page.waitForFunction(() => (window as any).reactDevToolsReady, {
+    timeout: 5000,
+  });
 
   // Enable debug logging
   await page.evaluate(() => {
@@ -15,41 +17,44 @@ test('debug react component names', async ({ page }) => {
   const hookInfo = await page.evaluate(() => {
     const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook) return { hasHook: false };
-    
+
     const renderers = Array.from(hook.renderers.keys());
-    let fiberRoots = [];
+    const fiberRoots = [];
     for (const rendererId of renderers) {
       const roots = hook.getFiberRoots(rendererId);
       fiberRoots.push(Array.from(roots).length);
     }
-    
+
     return {
       hasHook: true,
       renderers,
       fiberRoots,
-      supportsFiber: hook.supportsFiber
+      supportsFiber: hook.supportsFiber,
     };
   });
-  
+
   console.log('React DevTools Hook Info:', hookInfo);
 
   // Test manual fiber extraction
   const manualFiberTest = await page.evaluate(() => {
     const button = document.getElementById('test-button');
     if (!button) return { error: 'No button found' };
-    
+
     // Find fiber manually
-    const fiberKey = Object.keys(button).find(k => k.startsWith("__reactFiber$"));
-    if (!fiberKey) return { error: 'No fiber key found', keys: Object.keys(button) };
-    
+    const fiberKey = Object.keys(button).find((k) =>
+      k.startsWith('__reactFiber$')
+    );
+    if (!fiberKey)
+      return { error: 'No fiber key found', keys: Object.keys(button) };
+
     const fiber = (button as any)[fiberKey];
     if (!fiber) return { error: 'No fiber found' };
-    
+
     // Walk up to find component
     let current = fiber;
     let steps = 0;
     const walkInfo = [];
-    
+
     while (current && steps < 10) {
       walkInfo.push({
         step: steps,
@@ -57,32 +62,36 @@ test('debug react component names', async ({ page }) => {
         typeOf: typeof current.type,
         typeName: current.type?.name,
         displayName: current.type?.displayName,
-        debugSource: current._debugSource
+        debugSource: current._debugSource,
       });
-      
+
       if (current.type && typeof current.type === 'function') {
         return {
           success: true,
           walkInfo,
-          componentName: current.type.name || current.type.displayName || 'Anonymous',
+          componentName:
+            current.type.name || current.type.displayName || 'Anonymous',
           debugSource: current._debugSource,
-          foundAt: steps
+          foundAt: steps,
         };
       }
-      
+
       current = current.return;
       steps++;
     }
-    
+
     return { walkComplete: true, walkInfo, noComponentFound: true };
   });
-  
+
   console.log('Manual Fiber Test:', JSON.stringify(manualFiberTest, null, 2));
 
   // Test snapshot with debug logging
   const snapshot = await page.evaluate(async () => {
     (window as any).DEBUG_REACT_SNAPSHOT = true;
-    return await window.A11yCap.snapshot(document.body, { mode: 'ai', enableReact: true });
+    return await window.A11yCap.snapshot(document.body, {
+      mode: 'ai',
+      enableReact: true,
+    });
   });
 
   console.log('Final snapshot:', snapshot);

--- a/test/debug-source.spec.ts
+++ b/test/debug-source.spec.ts
@@ -1,23 +1,27 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Debug Source Information', () => {
-  test('should extract debug source info from data attributes', async ({ page }) => {
+  test('should extract debug source info from data attributes', async ({
+    page,
+  }) => {
     await page.goto('http://localhost:14652/');
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
 
     const debugSourceInfo = await page.evaluate(() => {
       const button = document.getElementById('test-button');
       if (!button) return { error: 'Button not found' };
-      
+
       // Check for data attributes from Babel plugin
       const dataDebugId = button.getAttribute('data-debug-id');
       const dataDebugSource = button.getAttribute('data-debug-source');
-      
+
       // Test extractReactInfo to see if it picks up debug source
       const extractReactInfo = window.A11yCap.extractReactInfo;
       let reactInfo = null;
       try {
-        reactInfo = extractReactInfo ? extractReactInfo(button) : 'extractReactInfo not found';
+        reactInfo = extractReactInfo
+          ? extractReactInfo(button)
+          : 'extractReactInfo not found';
       } catch (e) {
         reactInfo = { error: e.message };
       }
@@ -27,22 +31,26 @@ test.describe('Debug Source Information', () => {
         dataDebugId,
         dataDebugSource,
         hasDataAttributes: !!(dataDebugId || dataDebugSource),
-        reactInfo
+        reactInfo,
       };
     });
-    
+
     console.log('Debug source info:', debugSourceInfo);
 
     // Assertions
     expect(debugSourceInfo.hasButton).toBe(true);
-    
+
     // This test should FAIL if debug source info is not available
     if (!debugSourceInfo.hasDataAttributes) {
-      throw new Error('EXPECTED FAILURE: No debug source data attributes found. Babel plugin may not be working.');
+      throw new Error(
+        'EXPECTED FAILURE: No debug source data attributes found. Babel plugin may not be working.'
+      );
     }
-    
+
     if (!debugSourceInfo.reactInfo?.debugSource) {
-      throw new Error('EXPECTED FAILURE: extractReactInfo did not return debugSource. React utils may not be reading data attributes.');
+      throw new Error(
+        'EXPECTED FAILURE: extractReactInfo did not return debugSource. React utils may not be reading data attributes.'
+      );
     }
 
     // If we get here, debug source is working

--- a/test/mcp-tools.spec.ts
+++ b/test/mcp-tools.spec.ts
@@ -14,7 +14,7 @@ test.describe('MCP Tools Implementation', () => {
 
     expect(snapshot).toContain('React Test Page');
     expect(snapshot).toContain('[ref=');
-    
+
     // Test snapshot with different modes
     const expectSnapshot = await page.evaluate(() => {
       return window.A11yCap.snapshot(document.body, { mode: 'expect' });
@@ -68,14 +68,17 @@ test.describe('MCP Tools Implementation', () => {
 
     // Test typing text into input
     const testText = 'John Doe';
-    await page.evaluate((data) => {
-      const element = window.A11yCap.findElementByRef(data.ref);
-      if (element && element instanceof HTMLInputElement) {
-        element.value = data.text;
-        element.dispatchEvent(new Event('input', { bubbles: true }));
-        element.dispatchEvent(new Event('change', { bubbles: true }));
-      }
-    }, { ref: nameInputRef, text: testText });
+    await page.evaluate(
+      (data) => {
+        const element = window.A11yCap.findElementByRef(data.ref);
+        if (element && element instanceof HTMLInputElement) {
+          element.value = data.text;
+          element.dispatchEvent(new Event('input', { bubbles: true }));
+          element.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+      },
+      { ref: nameInputRef, text: testText }
+    );
 
     // Verify text was entered
     const inputValue = await page.locator('#name').inputValue();
@@ -99,23 +102,32 @@ test.describe('MCP Tools Implementation', () => {
 
     // Test typing slowly (character by character)
     const testText = 'test@example.com';
-    await page.evaluate(async (data) => {
-      const element = window.A11yCap.findElementByRef(data.ref);
-      if (element && element instanceof HTMLInputElement) {
-        element.value = ''; // Clear first
-        
-        // Type character by character
-        for (let i = 0; i < data.text.length; i++) {
-          const char = data.text[i];
-          element.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
-          element.dispatchEvent(new KeyboardEvent('keypress', { key: char, bubbles: true }));
-          element.value += char;
-          element.dispatchEvent(new Event('input', { bubbles: true }));
-          element.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
-          await new Promise(resolve => setTimeout(resolve, 10)); // Small delay
+    await page.evaluate(
+      async (data) => {
+        const element = window.A11yCap.findElementByRef(data.ref);
+        if (element && element instanceof HTMLInputElement) {
+          element.value = ''; // Clear first
+
+          // Type character by character
+          for (let i = 0; i < data.text.length; i++) {
+            const char = data.text[i];
+            element.dispatchEvent(
+              new KeyboardEvent('keydown', { key: char, bubbles: true })
+            );
+            element.dispatchEvent(
+              new KeyboardEvent('keypress', { key: char, bubbles: true })
+            );
+            element.value += char;
+            element.dispatchEvent(new Event('input', { bubbles: true }));
+            element.dispatchEvent(
+              new KeyboardEvent('keyup', { key: char, bubbles: true })
+            );
+            await new Promise((resolve) => setTimeout(resolve, 10)); // Small delay
+          }
         }
-      }
-    }, { ref: emailInputRef, text: testText });
+      },
+      { ref: emailInputRef, text: testText }
+    );
 
     // Verify text was entered
     const inputValue = await page.locator('#email').inputValue();
@@ -132,19 +144,30 @@ test.describe('MCP Tools Implementation', () => {
     });
 
     // Extract key test input ref
-    const inputMatch = snapshot.match(/textbox.*"Focus and press keys here".*\[ref=(e\d+)\]/);
+    const inputMatch = snapshot.match(
+      /textbox.*"Focus and press keys here".*\[ref=(e\d+)\]/
+    );
     expect(inputMatch).toBeTruthy();
     const inputRef = inputMatch![1];
 
     // Simulate pressing Enter key
-    await page.evaluate((data) => {
-      const element = window.A11yCap.findElementByRef(data.ref);
-      if (element) {
-        element.dispatchEvent(new KeyboardEvent('keydown', { key: data.key, bubbles: true }));
-        element.dispatchEvent(new KeyboardEvent('keypress', { key: data.key, bubbles: true }));
-        element.dispatchEvent(new KeyboardEvent('keyup', { key: data.key, bubbles: true }));
-      }
-    }, { ref: inputRef, key: 'Enter' });
+    await page.evaluate(
+      (data) => {
+        const element = window.A11yCap.findElementByRef(data.ref);
+        if (element) {
+          element.dispatchEvent(
+            new KeyboardEvent('keydown', { key: data.key, bubbles: true })
+          );
+          element.dispatchEvent(
+            new KeyboardEvent('keypress', { key: data.key, bubbles: true })
+          );
+          element.dispatchEvent(
+            new KeyboardEvent('keyup', { key: data.key, bubbles: true })
+          );
+        }
+      },
+      { ref: inputRef, key: 'Enter' }
+    );
 
     // Verify key press was registered
     const keyDisplay = await page.locator('#key-press-display').textContent();
@@ -183,7 +206,9 @@ test.describe('MCP Tools Implementation', () => {
     });
 
     // Extract select element ref
-    const selectMatch = snapshot.match(/combobox.*"Choose an option:".*\[ref=(e\d+)\]/);
+    const selectMatch = snapshot.match(
+      /combobox.*"Choose an option:".*\[ref=(e\d+)\]/
+    );
     expect(selectMatch).toBeTruthy();
     const selectRef = selectMatch![1];
 
@@ -193,19 +218,22 @@ test.describe('MCP Tools Implementation', () => {
 
     // Select an option
     const testValue = 'option2';
-    await page.evaluate((data) => {
-      const element = window.A11yCap.findElementByRef(data.ref);
-      if (element && element instanceof HTMLSelectElement) {
-        // Find the option and select it
-        for (let option of element.options) {
-          if (option.value === data.value) {
-            option.selected = true;
-            break;
+    await page.evaluate(
+      (data) => {
+        const element = window.A11yCap.findElementByRef(data.ref);
+        if (element && element instanceof HTMLSelectElement) {
+          // Find the option and select it
+          for (const option of element.options) {
+            if (option.value === data.value) {
+              option.selected = true;
+              break;
+            }
           }
+          element.dispatchEvent(new Event('change', { bubbles: true }));
         }
-        element.dispatchEvent(new Event('change', { bubbles: true }));
-      }
-    }, { ref: selectRef, value: testValue });
+      },
+      { ref: selectRef, value: testValue }
+    );
 
     // Verify selection
     const selectedValue = await page.locator('#test-select').inputValue();
@@ -224,16 +252,16 @@ test.describe('MCP Tools Implementation', () => {
 
     // Test waiting for text to appear
     await page.click('text=Start Loading (2s delay)');
-    
+
     // Verify loading message appears
     await expect(page.locator('text=Loading...')).toBeVisible();
-    
+
     // Wait for completion message
     await expect(page.locator('text=Loading complete!')).toBeVisible();
-    
+
     // Clear the message
     await page.click('text=Clear Message');
-    
+
     // Test that loading messages are gone
     await expect(page.locator('text=Loading...')).not.toBeVisible();
     await expect(page.locator('text=Loading complete!')).not.toBeVisible();
@@ -242,24 +270,26 @@ test.describe('MCP Tools Implementation', () => {
   test('should handle execute_js functionality', async ({ page }) => {
     // Test simple JavaScript execution
     const titleResult = await page.evaluate(() => {
-      return eval('document.title');
+      return document.title;
     });
     expect(titleResult).toBe('React App');
 
     // Test more complex JavaScript
     const buttonCount = await page.evaluate(() => {
-      return eval('document.querySelectorAll("button").length');
+      return document.querySelectorAll('button').length;
     });
     expect(buttonCount).toBeGreaterThan(0);
 
     // Test accessing React state indirectly
     const pageText = await page.evaluate(() => {
-      return eval('document.body.textContent.includes("React Test Page")');
+      return document.body.textContent.includes('React Test Page');
     });
     expect(pageText).toBe(true);
   });
 
-  test('should capture snapshots after actions (integration test)', async ({ page }) => {
+  test('should capture snapshots after actions (integration test)', async ({
+    page,
+  }) => {
     // Take initial snapshot
     const initialSnapshot = await page.evaluate(() => {
       return window.A11yCap.snapshotForAI(document.body, { enableReact: true });
@@ -269,7 +299,9 @@ test.describe('MCP Tools Implementation', () => {
     expect(initialSnapshot).toContain('Show Form');
 
     // Click the counter button
-    const buttonMatch = initialSnapshot.match(/button.*"Click me.*\[ref=(e\d+)\]/);
+    const buttonMatch = initialSnapshot.match(
+      /button.*"Click me.*\[ref=(e\d+)\]/
+    );
     expect(buttonMatch).toBeTruthy();
     const buttonRef = buttonMatch![1];
 
@@ -286,7 +318,9 @@ test.describe('MCP Tools Implementation', () => {
     expect(afterClickSnapshot).not.toBe(initialSnapshot);
 
     // Show form
-    const formButtonMatch = initialSnapshot.match(/button.*"Show Form".*\[ref=(e\d+)\]/);
+    const formButtonMatch = initialSnapshot.match(
+      /button.*"Show Form".*\[ref=(e\d+)\]/
+    );
     expect(formButtonMatch).toBeTruthy();
     const formButtonRef = formButtonMatch![1];
 
@@ -317,8 +351,10 @@ test.describe('MCP Tools Implementation', () => {
 
     // Extract various element refs
     const buttonMatch = snapshot.match(/button.*"Click me.*\[ref=(e\d+)\]/);
-    const headingMatch = snapshot.match(/heading.*"React Test Page".*\[ref=(e\d+)\]/);
-    
+    const headingMatch = snapshot.match(
+      /heading.*"React Test Page".*\[ref=(e\d+)\]/
+    );
+
     expect(buttonMatch).toBeTruthy();
     expect(headingMatch).toBeTruthy();
 
@@ -326,17 +362,20 @@ test.describe('MCP Tools Implementation', () => {
     const headingRef = headingMatch![1];
 
     // Test finding elements by ref
-    const elementsFound = await page.evaluate((refs) => {
-      const button = window.A11yCap.findElementByRef(refs.button);
-      const heading = window.A11yCap.findElementByRef(refs.heading);
-      const nonExistent = window.A11yCap.findElementByRef('e999');
+    const elementsFound = await page.evaluate(
+      (refs) => {
+        const button = window.A11yCap.findElementByRef(refs.button);
+        const heading = window.A11yCap.findElementByRef(refs.heading);
+        const nonExistent = window.A11yCap.findElementByRef('e999');
 
-      return {
-        buttonFound: button?.tagName?.toLowerCase(),
-        headingFound: heading?.tagName?.toLowerCase(),
-        nonExistentFound: nonExistent === null
-      };
-    }, { button: buttonRef, heading: headingRef });
+        return {
+          buttonFound: button?.tagName?.toLowerCase(),
+          headingFound: heading?.tagName?.toLowerCase(),
+          nonExistentFound: nonExistent === null,
+        };
+      },
+      { button: buttonRef, heading: headingRef }
+    );
 
     expect(elementsFound.buttonFound).toBe('button');
     expect(elementsFound.headingFound).toBe('h1');

--- a/test/react-devtools.spec.ts
+++ b/test/react-devtools.spec.ts
@@ -7,13 +7,15 @@ test.describe('React DevTools Integration', () => {
 
     // Wait for the library and React DevTools to load
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, { timeout: 5000 });
+    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, {
+      timeout: 5000,
+    });
 
     const result = await page.evaluate(() => {
       // Get the React DevTools hook
       const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       if (!hook) return { error: 'React DevTools hook not found' };
-      
+
       // Check if getFiberRoots exists, otherwise use a different approach
       let fiberNode = null;
       if (hook.getFiberRoots && typeof hook.getFiberRoots === 'function') {
@@ -23,7 +25,9 @@ test.describe('React DevTools Integration', () => {
         // Fallback: try to find fiber directly from DOM element
         const button = document.getElementById('test-button');
         if (button) {
-          const fiberKey = Object.keys(button).find(k => k.startsWith('__reactFiber'));
+          const fiberKey = Object.keys(button).find((k) =>
+            k.startsWith('__reactFiber')
+          );
           if (fiberKey) {
             fiberNode = (button as any)[fiberKey];
           }
@@ -33,7 +37,9 @@ test.describe('React DevTools Integration', () => {
       function findFiberForDom(dom: any): any {
         let node = dom;
         while (node) {
-          const fiberKey = Object.keys(node).find((k: string) => k.startsWith("__reactFiber$"));
+          const fiberKey = Object.keys(node).find((k: string) =>
+            k.startsWith('__reactFiber$')
+          );
           if (fiberKey) {
             const fiber = node[fiberKey];
             if (fiber) return fiber;
@@ -51,14 +57,14 @@ test.describe('React DevTools Integration', () => {
 
       // Find the fiber node for the button
       const fiber = findFiberForDom(button);
-      
+
       return {
         hasFiberRoot: !!fiberNode,
         hasButton: !!button,
         buttonText: button.textContent,
         hasFiber: !!fiber,
         fiberType: fiber ? fiber.type : null,
-        fiberProps: fiber ? Object.keys(fiber.memoizedProps || {}) : null
+        fiberProps: fiber ? Object.keys(fiber.memoizedProps || {}) : null,
       };
     });
 
@@ -75,15 +81,19 @@ test.describe('React DevTools Integration', () => {
 
   test('should find React component for form elements', async ({ page }) => {
     await page.goto('http://localhost:14652/');
-    
+
     // Remove CRA dev overlay for clicks
     await page.evaluate(() => {
-      const overlay = document.getElementById('webpack-dev-server-client-overlay');
+      const overlay = document.getElementById(
+        'webpack-dev-server-client-overlay'
+      );
       if (overlay) overlay.remove();
     });
-    
+
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, { timeout: 5000 });
+    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, {
+      timeout: 5000,
+    });
 
     // Click the "Show Form" button to render form elements
     await page.click('button:has-text("Show Form")');
@@ -92,7 +102,9 @@ test.describe('React DevTools Integration', () => {
       function findFiberForDom(dom: any): any {
         let node = dom;
         while (node) {
-          const fiberKey = Object.keys(node).find((k: string) => k.startsWith("__reactFiber$"));
+          const fiberKey = Object.keys(node).find((k: string) =>
+            k.startsWith('__reactFiber$')
+          );
           if (fiberKey) {
             const fiber = node[fiberKey];
             if (fiber) return fiber;
@@ -115,7 +127,7 @@ test.describe('React DevTools Integration', () => {
         formFiber: !!findFiberForDom(form),
         nameInputFiber: !!findFiberForDom(nameInput),
         emailInputFiber: !!findFiberForDom(emailInput),
-        formVisible: form.style.display !== 'none'
+        formVisible: form.style.display !== 'none',
       };
     });
 
@@ -129,21 +141,27 @@ test.describe('React DevTools Integration', () => {
 
   test('should track React component state changes', async ({ page }) => {
     await page.goto('http://localhost:14652/');
-    
+
     // Remove CRA dev overlay for clicks
     await page.evaluate(() => {
-      const overlay = document.getElementById('webpack-dev-server-client-overlay');
+      const overlay = document.getElementById(
+        'webpack-dev-server-client-overlay'
+      );
       if (overlay) overlay.remove();
     });
-    
+
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, { timeout: 5000 });
+    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, {
+      timeout: 5000,
+    });
 
     const initialState = await page.evaluate(() => {
       function findFiberForDom(dom: any): any {
         let node = dom;
         while (node) {
-          const fiberKey = Object.keys(node).find((k: string) => k.startsWith("__reactFiber$"));
+          const fiberKey = Object.keys(node).find((k: string) =>
+            k.startsWith('__reactFiber$')
+          );
           if (fiberKey) {
             const fiber = node[fiberKey];
             if (fiber) return fiber;
@@ -155,10 +173,10 @@ test.describe('React DevTools Integration', () => {
 
       const button = document.getElementById('test-button');
       const fiber = findFiberForDom(button);
-      
+
       return {
         buttonText: button?.textContent || '',
-        hasHooks: !!fiber?.memoizedState
+        hasHooks: !!fiber?.memoizedState,
       };
     });
 
@@ -169,7 +187,9 @@ test.describe('React DevTools Integration', () => {
       function findFiberForDom(dom: any): any {
         let node = dom;
         while (node) {
-          const fiberKey = Object.keys(node).find((k: string) => k.startsWith("__reactFiber$"));
+          const fiberKey = Object.keys(node).find((k: string) =>
+            k.startsWith('__reactFiber$')
+          );
           if (fiberKey) {
             const fiber = node[fiberKey];
             if (fiber) return fiber;
@@ -181,14 +201,17 @@ test.describe('React DevTools Integration', () => {
 
       const button = document.getElementById('test-button');
       const fiber = findFiberForDom(button);
-      
+
       return {
         buttonText: button?.textContent || '',
-        hasHooks: !!fiber?.memoizedState
+        hasHooks: !!fiber?.memoizedState,
       };
     });
 
-    console.log('State change:', { initial: initialState, afterClick: afterClickState });
+    console.log('State change:', {
+      initial: initialState,
+      afterClick: afterClickState,
+    });
 
     expect(initialState.buttonText).toContain('(0)');
     expect(afterClickState.buttonText).toContain('(1)');
@@ -196,35 +219,43 @@ test.describe('React DevTools Integration', () => {
 });
 
 test.describe('React-Aware Snapshot Integration', () => {
-  test('should include React component info when enableReact is true', async ({ page }) => {
+  test('should include React component info when enableReact is true', async ({
+    page,
+  }) => {
     await page.goto('http://localhost:14652/');
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, { timeout: 5000 });
+    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, {
+      timeout: 5000,
+    });
 
     const debugInfo = await page.evaluate(() => {
       const button = document.getElementById('test-button');
       if (!button) return { error: 'Button not found' };
-      
+
       // Enable debug logging
       (window as any).DEBUG_REACT_SNAPSHOT = true;
-      
+
       // Test extractReactInfo directly
       const { extractReactInfo } = window as any;
       let reactInfo = null;
       try {
-        reactInfo = extractReactInfo ? extractReactInfo(button) : 'extractReactInfo not found';
+        reactInfo = extractReactInfo
+          ? extractReactInfo(button)
+          : 'extractReactInfo not found';
       } catch (e) {
         reactInfo = { error: e.message };
       }
-      
+
       // Get fiber directly to inspect its properties
-      const fiberKey = Object.keys(button).find(k => k.startsWith('__reactFiber'));
+      const fiberKey = Object.keys(button).find((k) =>
+        k.startsWith('__reactFiber')
+      );
       let fiberProperties = [];
       let hasDebugSource = false;
       let debugSourceValue = null;
       let hasDebugOwner = false;
       let debugOwnerValue = null;
-      
+
       if (fiberKey) {
         const fiber = (button as any)[fiberKey];
         const componentFiber = (() => {
@@ -237,7 +268,7 @@ test.describe('React-Aware Snapshot Integration', () => {
           }
           return fiber;
         })();
-        
+
         fiberProperties = Object.keys(componentFiber);
         hasDebugSource = '_debugSource' in componentFiber;
         debugSourceValue = componentFiber._debugSource;
@@ -254,14 +285,17 @@ test.describe('React-Aware Snapshot Integration', () => {
         debugSourceValue,
         hasDebugOwner,
         debugOwnerValue,
-        reactInfo
+        reactInfo,
       };
     });
-    
+
     console.log('Debug info:', debugInfo);
 
     const snapshot = await page.evaluate(() => {
-      return window.A11yCap.snapshot(document.body, { mode: 'ai', enableReact: true });
+      return window.A11yCap.snapshot(document.body, {
+        mode: 'ai',
+        enableReact: true,
+      });
     });
 
     console.log('React-aware snapshot:', snapshot);
@@ -273,12 +307,17 @@ test.describe('React-Aware Snapshot Integration', () => {
     expect(snapshot).toContain('Click me');
   });
 
-  test('should not include React info when enableReact is false', async ({ page }) => {
+  test('should not include React info when enableReact is false', async ({
+    page,
+  }) => {
     await page.goto('http://localhost:14652/');
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
 
     const snapshot = await page.evaluate(() => {
-      return window.A11yCap.snapshot(document.body, { mode: 'ai', enableReact: false });
+      return window.A11yCap.snapshot(document.body, {
+        mode: 'ai',
+        enableReact: false,
+      });
     });
 
     console.log('Non-React snapshot:', snapshot);
@@ -291,31 +330,38 @@ test.describe('React-Aware Snapshot Integration', () => {
 
   test('should include React state and interaction hints', async ({ page }) => {
     await page.goto('http://localhost:14652/');
-    
+
     // Remove CRA dev overlay for clicks
     await page.evaluate(() => {
-      const overlay = document.getElementById('webpack-dev-server-client-overlay');
+      const overlay = document.getElementById(
+        'webpack-dev-server-client-overlay'
+      );
       if (overlay) overlay.remove();
     });
-    
+
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, { timeout: 5000 });
+    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, {
+      timeout: 5000,
+    });
 
     // Click the button to change state
     await page.click('#test-button');
-    
+
     // Show the form to get more React components
     await page.click('button:has-text("Show Form")');
 
     const snapshot = await page.evaluate(() => {
-      return window.A11yCap.snapshot(document.body, { mode: 'ai', enableReact: true });
+      return window.A11yCap.snapshot(document.body, {
+        mode: 'ai',
+        enableReact: true,
+      });
     });
 
     console.log('React snapshot with state and interactions:', snapshot);
 
     // Should contain interaction hints like onClick
     expect(snapshot).toContain('onClick');
-    
+
     // Should show form elements with React info
     expect(snapshot).toContain('textbox');
   });
@@ -323,7 +369,9 @@ test.describe('React-Aware Snapshot Integration', () => {
   test('should work with snapshotForAI function', async ({ page }) => {
     await page.goto('http://localhost:14652/');
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, { timeout: 5000 });
+    await page.waitForFunction(() => window.__REACT_DEVTOOLS_GLOBAL_HOOK__, {
+      timeout: 5000,
+    });
 
     const snapshot = await page.evaluate(() => {
       return window.A11yCap.snapshotForAI(document.body, { enableReact: true });
@@ -336,5 +384,4 @@ test.describe('React-Aware Snapshot Integration', () => {
     expect(snapshot).toContain('button');
     expect(snapshot).toContain('[component=');
   });
-
 });

--- a/test/readability.spec.ts
+++ b/test/readability.spec.ts
@@ -1,10 +1,12 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Readability Tool', () => {
-  test('should extract readable content from article page', async ({ page }) => {
+  test('should extract readable content from article page', async ({
+    page,
+  }) => {
     // Navigate to test server
     await page.goto('http://localhost:14652/');
-    
+
     // Create a simple article page
     await page.evaluate(() => {
       document.body.innerHTML = `
@@ -29,16 +31,16 @@ test.describe('Readability Tool', () => {
 
     // Wait for A11yCap to be available
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    
+
     // Execute the readability tool
     const result = await page.evaluate(async () => {
       const { toolHandlers } = window.A11yCap;
-      const handler = toolHandlers['get_readability'];
-      
+      const handler = toolHandlers.get_readability;
+
       if (!handler) {
         throw new Error('get_readability tool not found');
       }
-      
+
       const message = {
         id: 'test-1',
         type: 'get_readability' as const,
@@ -48,10 +50,10 @@ test.describe('Readability Tool', () => {
           maxContentLength: 5000,
         },
       };
-      
+
       return await handler.execute(message);
     });
-    
+
     // Verify the result is now human-readable text
     expect(typeof result).toBe('string');
     expect(result).toContain('Test Article');
@@ -63,7 +65,7 @@ test.describe('Readability Tool', () => {
 
   test('should handle pages without substantial content', async ({ page }) => {
     await page.goto('http://localhost:14652/');
-    
+
     // Create a page with only navigation (no article content)
     await page.evaluate(() => {
       document.body.innerHTML = `
@@ -80,12 +82,12 @@ test.describe('Readability Tool', () => {
 
     // Wait for A11yCap to be available
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    
+
     // Execute the readability tool
     const result = await page.evaluate(async () => {
       const { toolHandlers } = window.A11yCap;
-      const handler = toolHandlers['get_readability'];
-      
+      const handler = toolHandlers.get_readability;
+
       const message = {
         id: 'test-2',
         type: 'get_readability' as const,
@@ -95,10 +97,10 @@ test.describe('Readability Tool', () => {
           maxContentLength: 5000,
         },
       };
-      
+
       return await handler.execute(message);
     });
-    
+
     // With minimal content, readability tool should return a message
     expect(typeof result).toBe('string');
     // Should indicate limited content or provide what it could extract
@@ -107,7 +109,7 @@ test.describe('Readability Tool', () => {
 
   test('should respect maxContentLength option', async ({ page }) => {
     await page.goto('http://localhost:14652/');
-    
+
     // Create a page with long content
     await page.evaluate(() => {
       const longText = 'This is a very long paragraph. '.repeat(100);
@@ -126,12 +128,12 @@ test.describe('Readability Tool', () => {
 
     // Wait for A11yCap to be available
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
-    
+
     // Execute with a small maxContentLength
     const result = await page.evaluate(async () => {
       const { toolHandlers } = window.A11yCap;
-      const handler = toolHandlers['get_readability'];
-      
+      const handler = toolHandlers.get_readability;
+
       const message = {
         id: 'test-3',
         type: 'get_readability' as const,
@@ -141,10 +143,10 @@ test.describe('Readability Tool', () => {
           maxContentLength: 500,
         },
       };
-      
+
       return await handler.execute(message);
     });
-    
+
     expect(typeof result).toBe('string');
     expect(result.length).toBeGreaterThan(0);
     // Should contain some indication of content, may be truncated

--- a/test/selector-snapshot.spec.ts
+++ b/test/selector-snapshot.spec.ts
@@ -1,21 +1,23 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Selector Snapshot Functionality', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('http://localhost:14652');
   });
 
-  test('should capture snapshot using CSS selector for buttons', async ({ page }) => {
+  test('should capture snapshot using CSS selector for buttons', async ({
+    page,
+  }) => {
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-selector-snapshot',
         type: 'take_snapshot',
         payload: {
           selector: 'button',
           mode: 'ai',
           enableReact: true,
-          max_bytes: 8192
-        }
+          max_bytes: 8192,
+        },
       });
     });
 
@@ -25,17 +27,19 @@ test.describe('Selector Snapshot Functionality', () => {
     expect(result).toContain('button "Show Form"');
   });
 
-  test('should capture snapshot using specific CSS selector', async ({ page }) => {
+  test('should capture snapshot using specific CSS selector', async ({
+    page,
+  }) => {
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-specific-selector',
         type: 'take_snapshot',
         payload: {
           selector: 'h1',
           mode: 'ai',
           enableReact: true,
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     });
 
@@ -44,14 +48,14 @@ test.describe('Selector Snapshot Functionality', () => {
 
   test('should handle invalid CSS selector gracefully', async ({ page }) => {
     const resultPromise = page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-invalid-selector',
         type: 'take_snapshot',
         payload: {
           selector: 'invalid[selector[',
           mode: 'ai',
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     });
 
@@ -60,31 +64,33 @@ test.describe('Selector Snapshot Functionality', () => {
 
   test('should handle selector with no matches', async ({ page }) => {
     const resultPromise = page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-no-matches',
         type: 'take_snapshot',
         payload: {
           selector: '.nonexistent-class',
           mode: 'ai',
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     });
 
-    await expect(resultPromise).rejects.toThrow('No elements found matching selector');
+    await expect(resultPromise).rejects.toThrow(
+      'No elements found matching selector'
+    );
   });
 
   test('should respect size limit with multiple elements', async ({ page }) => {
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-size-limit',
         type: 'take_snapshot',
         payload: {
           selector: 'div',
           mode: 'ai',
           enableReact: true,
-          max_bytes: 500 // Very small limit to trigger truncation
-        }
+          max_bytes: 500, // Very small limit to trigger truncation
+        },
       });
     });
 
@@ -93,17 +99,19 @@ test.describe('Selector Snapshot Functionality', () => {
     // Should be truncated before capturing all divs
   });
 
-  test('should work with single element selector (no headers)', async ({ page }) => {
+  test('should work with single element selector (no headers)', async ({
+    page,
+  }) => {
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-single-element',
         type: 'take_snapshot',
         payload: {
           selector: 'h1',
           mode: 'ai',
           enableReact: true,
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     });
 
@@ -112,14 +120,16 @@ test.describe('Selector Snapshot Functionality', () => {
     expect(result).toContain('heading "React Test Page"');
   });
 
-  test('should preserve refs parameter behavior when refs is specified', async ({ page }) => {
+  test('should preserve refs parameter behavior when refs is specified', async ({
+    page,
+  }) => {
     // First get a snapshot to find a ref
     await page.evaluate(() => {
       return window.A11yCap.snapshotForAI(document.body);
     });
 
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-refs-priority',
         type: 'take_snapshot',
         payload: {
@@ -127,8 +137,8 @@ test.describe('Selector Snapshot Functionality', () => {
           selector: 'button', // Should be ignored
           mode: 'ai',
           enableReact: true,
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     });
 
@@ -145,15 +155,15 @@ test.describe('Selector Snapshot Functionality', () => {
     });
 
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-multiple-refs',
         type: 'take_snapshot',
         payload: {
           refs: ['e5', 'e7'], // Multiple refs
           mode: 'ai',
           enableReact: true,
-          max_bytes: 8192
-        }
+          max_bytes: 8192,
+        },
       });
     });
 
@@ -171,22 +181,22 @@ test.describe('Selector Snapshot Functionality', () => {
 
     // Capture console warnings
     const consoleMessages: string[] = [];
-    page.on('console', msg => {
+    page.on('console', (msg) => {
       if (msg.type() === 'warning') {
         consoleMessages.push(msg.text());
       }
     });
 
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-missing-refs',
         type: 'take_snapshot',
         payload: {
           refs: ['e5', 'nonexistent'], // One valid, one missing
           mode: 'ai',
           enableReact: true,
-          max_bytes: 8192
-        }
+          max_bytes: 8192,
+        },
       });
     });
 
@@ -195,38 +205,40 @@ test.describe('Selector Snapshot Functionality', () => {
     // Should warn about missing ref
     expect(consoleMessages).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('Elements not found with refs: nonexistent')
+        expect.stringContaining('Elements not found with refs: nonexistent'),
       ])
     );
   });
 
   test('should handle all missing refs with error', async ({ page }) => {
     const resultPromise = page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-all-missing-refs',
         type: 'take_snapshot',
         payload: {
           refs: ['nonexistent1', 'nonexistent2'], // All missing
           mode: 'ai',
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     });
 
-    await expect(resultPromise).rejects.toThrow('No elements found with refs: nonexistent1, nonexistent2');
+    await expect(resultPromise).rejects.toThrow(
+      'No elements found with refs: nonexistent1, nonexistent2'
+    );
   });
 
   test('should handle complex CSS selectors', async ({ page }) => {
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-complex-selector',
         type: 'take_snapshot',
         payload: {
           selector: 'button, input[type="text"]',
           mode: 'ai',
           enableReact: true,
-          max_bytes: 8192
-        }
+          max_bytes: 8192,
+        },
       });
     });
 
@@ -239,7 +251,7 @@ test.describe('Selector Snapshot Functionality', () => {
 
   test('should capture elements within bounding box', async ({ page }) => {
     const result = await page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-bounding-box',
         type: 'take_snapshot',
         payload: {
@@ -247,12 +259,12 @@ test.describe('Selector Snapshot Functionality', () => {
             x: 0,
             y: 0,
             width: 200,
-            height: 150
+            height: 150,
           },
           mode: 'ai',
           enableReact: true,
-          max_bytes: 8192
-        }
+          max_bytes: 8192,
+        },
       });
     });
 
@@ -265,23 +277,25 @@ test.describe('Selector Snapshot Functionality', () => {
 
   test('should handle bounding box with no elements', async ({ page }) => {
     const resultPromise = page.evaluate(() => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-empty-bounding-box',
         type: 'take_snapshot',
         payload: {
           boundingBox: {
-            x: 5000,  // Way off screen
+            x: 5000, // Way off screen
             y: 5000,
             width: 100,
-            height: 100
+            height: 100,
           },
           mode: 'ai',
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     });
 
-    await expect(resultPromise).rejects.toThrow('No elements found within bounding box (5000, 5000, 100x100)');
+    await expect(resultPromise).rejects.toThrow(
+      'No elements found within bounding box (5000, 5000, 100x100)'
+    );
   });
 
   test('should capture specific area with bounding box', async ({ page }) => {
@@ -294,14 +308,14 @@ test.describe('Selector Snapshot Functionality', () => {
         x: rect.left,
         y: rect.top,
         width: rect.width,
-        height: rect.height
+        height: rect.height,
       };
     });
 
     expect(buttonInfo).not.toBeNull();
 
     const result = await page.evaluate((buttonRect) => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-specific-bounding-box',
         type: 'take_snapshot',
         payload: {
@@ -309,12 +323,12 @@ test.describe('Selector Snapshot Functionality', () => {
             x: buttonRect.x - 10,
             y: buttonRect.y - 10,
             width: buttonRect.width + 20,
-            height: buttonRect.height + 20
+            height: buttonRect.height + 20,
           },
           mode: 'ai',
           enableReact: true,
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     }, buttonInfo);
 
@@ -323,7 +337,9 @@ test.describe('Selector Snapshot Functionality', () => {
     expect(result).toContain('boundingBox');
   });
 
-  test('should handle bounding box capturing multiple elements with headers', async ({ page }) => {
+  test('should handle bounding box capturing multiple elements with headers', async ({
+    page,
+  }) => {
     // Get heading position - this will catch multiple overlapping elements including containers
     const headingInfo = await page.evaluate(() => {
       const heading = document.querySelector('h1');
@@ -333,14 +349,14 @@ test.describe('Selector Snapshot Functionality', () => {
         x: rect.left,
         y: rect.top,
         width: rect.width,
-        height: rect.height
+        height: rect.height,
       };
     });
 
     expect(headingInfo).not.toBeNull();
 
     const result = await page.evaluate((headingRect) => {
-      return window.A11yCap.toolHandlers['take_snapshot'].execute({
+      return window.A11yCap.toolHandlers.take_snapshot.execute({
         id: 'test-multi-bounding-box',
         type: 'take_snapshot',
         payload: {
@@ -348,12 +364,12 @@ test.describe('Selector Snapshot Functionality', () => {
             x: headingRect.x,
             y: headingRect.y,
             width: headingRect.width,
-            height: headingRect.height
+            height: headingRect.height,
           },
           mode: 'ai',
           enableReact: true,
-          max_bytes: 4096
-        }
+          max_bytes: 4096,
+        },
       });
     }, headingInfo);
 

--- a/test/show-element-picker.spec.ts
+++ b/test/show-element-picker.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Element Picker Tool', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to test app
     await page.goto('http://localhost:14652/');
-    
+
     // Wait for A11yCap to be available
     await page.waitForFunction(() => window.A11yCap, { timeout: 5000 });
   });
@@ -15,41 +15,43 @@ test.describe('Element Picker Tool', () => {
       const picker = window.A11yCap.getElementPicker();
       return picker !== null;
     });
-    
+
     expect(pickerExists).toBe(true);
-    
+
     // Start element picker (non-blocking in test context)
     await page.evaluate(() => {
       const picker = window.A11yCap.getElementPicker();
       // Store promise globally so we can check it later
       window.__pickerPromise = picker.pick();
     });
-    
+
     // Wait for overlay to appear
     await page.waitForTimeout(100);
-    
+
     // Check that glass pane is visible
     const glassPaneVisible = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
-      return glassPane && window.getComputedStyle(glassPane).display === 'block';
+      return (
+        glassPane && window.getComputedStyle(glassPane).display === 'block'
+      );
     });
-    
+
     expect(glassPaneVisible).toBe(true);
-    
+
     // Check for control panel in shadow DOM
     const hasControls = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return false;
-      
+
       const controls = glassPane.shadowRoot.querySelector('.controls');
       const doneButton = glassPane.shadowRoot.querySelector('.done');
       const cancelButton = glassPane.shadowRoot.querySelector('.cancel');
-      
+
       return !!(controls && doneButton && cancelButton);
     });
-    
+
     expect(hasControls).toBe(true);
-    
+
     // Cancel the picker
     await page.keyboard.press('Escape');
   });
@@ -60,62 +62,69 @@ test.describe('Element Picker Tool', () => {
       const picker = window.A11yCap.getElementPicker();
       window.__pickerPromise = picker.pick();
     });
-    
+
     await page.waitForTimeout(100);
-    
+
     // Click the test button through the overlay
     const buttonSelector = '#test-button';
     const button = await page.$(buttonSelector);
     const buttonBox = await button?.boundingBox();
-    
+
     expect(buttonBox).toBeTruthy();
-    
+
     if (buttonBox) {
       // Click on the glass pane at button position
-      await page.mouse.click(buttonBox.x + buttonBox.width / 2, buttonBox.y + buttonBox.height / 2);
+      await page.mouse.click(
+        buttonBox.x + buttonBox.width / 2,
+        buttonBox.y + buttonBox.height / 2
+      );
     }
-    
+
     await page.waitForTimeout(100);
-    
+
     // Check selection
     const selectedCount = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return 0;
-      
-      const selected = glassPane.shadowRoot.querySelectorAll('.highlight.selected');
+
+      const selected = glassPane.shadowRoot.querySelectorAll(
+        '.highlight.selected'
+      );
       return selected.length;
     });
-    
+
     expect(selectedCount).toBe(1);
-    
+
     // Check counter updated
     const counterText = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return '';
-      
+
       const counter = glassPane.shadowRoot.querySelector('.selected-count');
       return counter?.textContent || '';
     });
-    
+
     expect(counterText).toBe('Selected: 1');
-    
+
     // Complete selection
     const result = await page.evaluate(async () => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return null;
-      
-      const doneButton = glassPane.shadowRoot.querySelector('.done') as HTMLElement;
+
+      const doneButton = glassPane.shadowRoot.querySelector(
+        '.done'
+      ) as HTMLElement;
       doneButton?.click();
-      
+
       // Wait for promise to resolve
       const picked = await window.__pickerPromise;
       return picked;
     });
-    
+
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       selector: expect.stringContaining('button'),
-      text: expect.stringContaining('Click me')
+      text: expect.stringContaining('Click me'),
     });
   });
 
@@ -125,26 +134,28 @@ test.describe('Element Picker Tool', () => {
       const picker = window.A11yCap.getElementPicker();
       window.__pickerPromise = picker.pick();
     });
-    
+
     await page.waitForTimeout(100);
-    
+
     // Press Escape
     await page.keyboard.press('Escape');
-    
+
     // Check result
     const result = await page.evaluate(async () => {
       const picked = await window.__pickerPromise;
       return picked;
     });
-    
+
     expect(result).toHaveLength(0);
-    
+
     // Check overlay is hidden
     const overlayHidden = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
-      return !glassPane || window.getComputedStyle(glassPane).display === 'none';
+      return (
+        !glassPane || window.getComputedStyle(glassPane).display === 'none'
+      );
     });
-    
+
     expect(overlayHidden).toBe(true);
   });
 
@@ -152,127 +163,149 @@ test.describe('Element Picker Tool', () => {
     // Show the form first
     await page.click('#show-form-button');
     await page.waitForSelector('#test-form', { state: 'visible' });
-    
+
     // Start picker
     await page.evaluate(() => {
       const picker = window.A11yCap.getElementPicker();
       window.__pickerPromise = picker.pick();
     });
-    
+
     await page.waitForTimeout(100);
-    
+
     // Hold Shift for multi-select
     await page.keyboard.down('Shift');
-    
+
     // Select multiple form elements
     const nameInput = await page.$('#name');
     const nameBox = await nameInput?.boundingBox();
     if (nameBox) {
-      await page.mouse.click(nameBox.x + nameBox.width / 2, nameBox.y + nameBox.height / 2);
+      await page.mouse.click(
+        nameBox.x + nameBox.width / 2,
+        nameBox.y + nameBox.height / 2
+      );
       await page.waitForTimeout(50);
     }
-    
+
     const emailInput = await page.$('#email');
     const emailBox = await emailInput?.boundingBox();
     if (emailBox) {
-      await page.mouse.click(emailBox.x + emailBox.width / 2, emailBox.y + emailBox.height / 2);
+      await page.mouse.click(
+        emailBox.x + emailBox.width / 2,
+        emailBox.y + emailBox.height / 2
+      );
       await page.waitForTimeout(50);
     }
-    
+
     await page.keyboard.up('Shift');
-    
+
     // Check selection count
     const selectedCount = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return 0;
-      
+
       const counter = glassPane.shadowRoot.querySelector('.selected-count');
       const text = counter?.textContent || '';
       const match = text.match(/Selected: (\d+)/);
-      return match ? parseInt(match[1]) : 0;
+      return match ? Number.parseInt(match[1]) : 0;
     });
-    
+
     expect(selectedCount).toBe(2);
-    
+
     // Complete selection
     const result = await page.evaluate(async () => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return null;
-      
-      const doneButton = glassPane.shadowRoot.querySelector('.done') as HTMLElement;
+
+      const doneButton = glassPane.shadowRoot.querySelector(
+        '.done'
+      ) as HTMLElement;
       doneButton?.click();
-      
+
       const picked = await window.__pickerPromise;
       return picked;
     });
-    
+
     expect(result).toHaveLength(2);
     expect(result[0].selector).toContain('#name');
     expect(result[1].selector).toContain('#email');
   });
 
-  test('should generate correct CSS selectors for test app elements', async ({ page }) => {
+  test('should generate correct CSS selectors for test app elements', async ({
+    page,
+  }) => {
     // Start picker
     await page.evaluate(() => {
       const picker = window.A11yCap.getElementPicker();
       window.__pickerPromise = picker.pick();
     });
-    
+
     await page.waitForTimeout(100);
-    
+
     // Select the test button (has ID)
     const button = await page.$('#test-button');
     const buttonBox = await button?.boundingBox();
     if (buttonBox) {
-      await page.mouse.click(buttonBox.x + buttonBox.width / 2, buttonBox.y + buttonBox.height / 2);
+      await page.mouse.click(
+        buttonBox.x + buttonBox.width / 2,
+        buttonBox.y + buttonBox.height / 2
+      );
     }
-    
+
     // Complete and check result
     const result = await page.evaluate(async () => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return null;
-      
-      const doneButton = glassPane.shadowRoot.querySelector('.done') as HTMLElement;
+
+      const doneButton = glassPane.shadowRoot.querySelector(
+        '.done'
+      ) as HTMLElement;
       doneButton?.click();
-      
+
       const picked = await window.__pickerPromise;
       return picked;
     });
-    
+
     expect(result).toHaveLength(1);
     expect(result[0].selector).toBe('#test-button');
     expect(result[0].text).toContain('Click me');
   });
 
-  test('should return bounding boxes for selected elements', async ({ page }) => {
+  test('should return bounding boxes for selected elements', async ({
+    page,
+  }) => {
     // Start picker
     await page.evaluate(() => {
       const picker = window.A11yCap.getElementPicker();
       window.__pickerPromise = picker.pick();
     });
-    
+
     await page.waitForTimeout(100);
-    
+
     // Select the test button
     const button = await page.$('#test-button');
     const buttonBox = await button?.boundingBox();
-    
+
     if (buttonBox) {
-      await page.mouse.click(buttonBox.x + buttonBox.width / 2, buttonBox.y + buttonBox.height / 2);
+      await page.mouse.click(
+        buttonBox.x + buttonBox.width / 2,
+        buttonBox.y + buttonBox.height / 2
+      );
     }
-    
+
     // Complete selection
     const result = await page.evaluate(async () => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return null;
-      
-      const doneButton = glassPane.shadowRoot.querySelector('.done') as HTMLElement;
+
+      const doneButton = glassPane.shadowRoot.querySelector(
+        '.done'
+      ) as HTMLElement;
       doneButton?.click();
-      
+
       const picked = await window.__pickerPromise;
       return picked;
     });
-    
+
     expect(result).toHaveLength(1);
     expect(result[0].boundingBox).toBeDefined();
     expect(result[0].boundingBox.x).toBeGreaterThanOrEqual(0);
@@ -287,29 +320,32 @@ test.describe('Element Picker Tool', () => {
       const picker = window.A11yCap.getElementPicker();
       window.__pickerPromise = picker.pick();
     });
-    
+
     await page.waitForTimeout(100);
-    
+
     // Select an element
     const button = await page.$('#test-button');
     const buttonBox = await button?.boundingBox();
-    
+
     if (buttonBox) {
-      await page.mouse.click(buttonBox.x + buttonBox.width / 2, buttonBox.y + buttonBox.height / 2);
+      await page.mouse.click(
+        buttonBox.x + buttonBox.width / 2,
+        buttonBox.y + buttonBox.height / 2
+      );
     }
-    
+
     await page.waitForTimeout(100);
-    
+
     // Use keyboard shortcut to complete (Cmd/Ctrl + Enter)
     const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
     await page.keyboard.press(`${modifier}+Enter`);
-    
+
     // Check result
     const result = await page.evaluate(async () => {
       const picked = await window.__pickerPromise;
       return picked;
     });
-    
+
     expect(result).toHaveLength(1);
     expect(result[0].text).toContain('Click me');
   });
@@ -320,40 +356,44 @@ test.describe('Element Picker Tool', () => {
       const picker = window.A11yCap.getElementPicker();
       window.__pickerPromise = picker.pick();
     });
-    
+
     await page.waitForTimeout(100);
-    
+
     // Move mouse over button
     const button = await page.$('#test-button');
     const buttonBox = await button?.boundingBox();
-    
+
     if (buttonBox) {
-      await page.mouse.move(buttonBox.x + buttonBox.width / 2, buttonBox.y + buttonBox.height / 2);
+      await page.mouse.move(
+        buttonBox.x + buttonBox.width / 2,
+        buttonBox.y + buttonBox.height / 2
+      );
       await page.waitForTimeout(100);
     }
-    
+
     // Check for hover highlight
     const hasHoverHighlight = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return false;
-      
-      const highlights = glassPane.shadowRoot.querySelectorAll('.highlight.hovered');
+
+      const highlights =
+        glassPane.shadowRoot.querySelectorAll('.highlight.hovered');
       return highlights.length > 0;
     });
-    
+
     expect(hasHoverHighlight).toBe(true);
-    
+
     // Check for tooltip
     const hasTooltip = await page.evaluate(() => {
       const glassPane = document.querySelector('x-a11ycap-glass');
       if (!glassPane?.shadowRoot) return false;
-      
+
       const tooltip = glassPane.shadowRoot.querySelector('.tooltip');
       return tooltip !== null && tooltip.textContent !== '';
     });
-    
+
     expect(hasTooltip).toBe(true);
-    
+
     // Cancel picker
     await page.keyboard.press('Escape');
   });

--- a/test/snapshot-by-ref.spec.ts
+++ b/test/snapshot-by-ref.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Snapshot by Ref', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate to our React test page via HTTP server  
+    // Navigate to our React test page via HTTP server
     await page.goto('http://localhost:14652/');
 
     // Wait for the library to load
@@ -85,29 +85,42 @@ test.describe('Snapshot by Ref', () => {
     console.log('Full snapshot with form:', fullSnapshot);
 
     // Find the form/container ref
-    const containerRefMatch = fullSnapshot.match(/generic.*?\[ref=(e\d+)\].*form/i);
+    const containerRefMatch = fullSnapshot.match(
+      /generic.*?\[ref=(e\d+)\].*form/i
+    );
     if (!containerRefMatch) {
       // Look for any container element with nested content
-      const anyContainerMatch = fullSnapshot.match(/generic.*?\[ref=(e\d+)\](?:\s*\[[^\]]+\])?:/);
+      const anyContainerMatch = fullSnapshot.match(
+        /generic.*?\[ref=(e\d+)\](?:\s*\[[^\]]+\])?:/
+      );
       expect(anyContainerMatch).toBeTruthy();
-      
+
       const containerRef = anyContainerMatch![1];
       console.log('Found container ref:', containerRef);
 
       // Take a limited size snapshot of that container
-      const limitedContainerSnapshot = await page.evaluate(async (args) => {
-        const element = window.A11yCap.findElementByRef(args.ref);
-        if (!element) return null;
-        return await window.A11yCap.snapshotForAI(element, { max_bytes: args.maxBytes });
-      }, { ref: containerRef, maxBytes: 150 });
+      const limitedContainerSnapshot = await page.evaluate(
+        async (args) => {
+          const element = window.A11yCap.findElementByRef(args.ref);
+          if (!element) return null;
+          return await window.A11yCap.snapshotForAI(element, {
+            max_bytes: args.maxBytes,
+          });
+        },
+        { ref: containerRef, maxBytes: 150 }
+      );
 
       console.log('Limited container snapshot:', limitedContainerSnapshot);
 
       if (limitedContainerSnapshot) {
         // When truncated, a warning message is appended, so total length will exceed max_bytes
-        if (limitedContainerSnapshot.includes('[WARNING: Snapshot was truncated')) {
+        if (
+          limitedContainerSnapshot.includes('[WARNING: Snapshot was truncated')
+        ) {
           // The actual content is truncated to 150 bytes, but warning is added
-          expect(limitedContainerSnapshot).toContain('[WARNING: Snapshot was truncated');
+          expect(limitedContainerSnapshot).toContain(
+            '[WARNING: Snapshot was truncated'
+          );
           expect(limitedContainerSnapshot.length).toBeGreaterThan(150); // Due to warning
         } else {
           // If not truncated, should be within limit
@@ -127,7 +140,9 @@ test.describe('Snapshot by Ref', () => {
     expect(result).toBeNull();
   });
 
-  test('should work with different modes when snapshotting by ref', async ({ page }) => {
+  test('should work with different modes when snapshotting by ref', async ({
+    page,
+  }) => {
     // Get a button ref first
     const fullSnapshot = await page.evaluate(async () => {
       return await window.A11yCap.snapshotForAI(document.body);
@@ -143,8 +158,10 @@ test.describe('Snapshot by Ref', () => {
       if (!element) return null;
 
       const aiMode = await window.A11yCap.snapshot(element, { mode: 'ai' });
-      const expectMode = await window.A11yCap.snapshot(element, { mode: 'expect' });
-      
+      const expectMode = await window.A11yCap.snapshot(element, {
+        mode: 'expect',
+      });
+
       return { aiMode, expectMode };
     }, buttonRef);
 
@@ -152,11 +169,11 @@ test.describe('Snapshot by Ref', () => {
     console.log('Expect mode button snapshot:', results!.expectMode);
 
     expect(results).toBeTruthy();
-    
+
     // AI mode should have refs, expect mode should not
     expect(results!.aiMode).toMatch(/\[ref=e\d+\]/);
     expect(results!.expectMode).not.toMatch(/\[ref=e\d+\]/);
-    
+
     // Both should contain the button text
     expect(results!.aiMode).toContain('Click me');
     expect(results!.expectMode).toContain('Click me');
@@ -175,9 +192,10 @@ test.describe('Snapshot by Ref', () => {
     console.log('Full snapshot with nested elements:', fullSnapshot);
 
     // Find any nested element ref (look for textbox or any input)
-    const nestedRefMatch = fullSnapshot.match(/textbox.*?\[ref=(e\d+)\]/) || 
-                          fullSnapshot.match(/generic.*?\[ref=(e\d+)\].*textbox/);
-    
+    const nestedRefMatch =
+      fullSnapshot.match(/textbox.*?\[ref=(e\d+)\]/) ||
+      fullSnapshot.match(/generic.*?\[ref=(e\d+)\].*textbox/);
+
     if (nestedRefMatch) {
       const nestedRef = nestedRefMatch[1];
       console.log('Found nested element ref:', nestedRef);

--- a/test/snapshotForAI.spec.ts
+++ b/test/snapshotForAI.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('snapshotForAI', () => {
   test('should generate basic snapshot for simple button', async ({ page }) => {
-    // Navigate to our React test page via HTTP server  
+    // Navigate to our React test page via HTTP server
     await page.goto('http://localhost:14652/');
 
     // Wait for the library to load
@@ -151,7 +151,7 @@ test.describe('snapshotForAI', () => {
 
 test.describe('snapshot (non-AI modes)', () => {
   test('should generate expect mode snapshot', async ({ page }) => {
-    // Navigate to our React test page via HTTP server  
+    // Navigate to our React test page via HTTP server
     await page.goto('http://localhost:14652/');
 
     // Wait for the library to load

--- a/test/user-interactions.spec.ts
+++ b/test/user-interactions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('User Interaction Recording', () => {
   test.beforeEach(async ({ page }) => {
@@ -13,7 +13,7 @@ test.describe('User Interaction Recording', () => {
       return window.A11yCap.clearEvents();
     });
 
-    // Click the button to generate interaction events  
+    // Click the button to generate interaction events
     await page.click('#test-button');
 
     // Get recorded interactions
@@ -24,7 +24,7 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'click',
           limit: 10,
-        }
+        },
       });
     });
 
@@ -50,7 +50,7 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'input',
           limit: 10,
-        }
+        },
       });
     });
 
@@ -68,7 +68,7 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'navigation',
           limit: 10,
-        }
+        },
       });
     });
 
@@ -85,7 +85,7 @@ test.describe('User Interaction Recording', () => {
 
     // Focus on the input field
     await page.focus('#key-test-input');
-    
+
     // Blur by clicking elsewhere
     await page.click('body');
 
@@ -96,7 +96,7 @@ test.describe('User Interaction Recording', () => {
         type: 'get_user_interactions',
         payload: {
           limit: 10,
-        }
+        },
       });
     });
 
@@ -106,7 +106,7 @@ test.describe('User Interaction Recording', () => {
   });
 
   test('should record keyboard events', async ({ page }) => {
-    // Clear any existing events  
+    // Clear any existing events
     await page.evaluate(() => {
       return window.A11yCap.clearEvents();
     });
@@ -124,7 +124,7 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'keydown',
           limit: 10,
-        }
+        },
       });
     });
 
@@ -147,7 +147,7 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'click',
           limit: 10,
-        }
+        },
       });
     });
 
@@ -173,7 +173,7 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'click',
           limit: 10,
-        }
+        },
       });
     });
 
@@ -185,13 +185,13 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'input',
           limit: 10,
-        }
+        },
       });
     });
 
     expect(clickInteractions).toContain('Click on button');
     expect(clickInteractions).not.toContain('Type in input');
-    
+
     expect(inputInteractions).toContain('Type in input');
     expect(inputInteractions).not.toContain('Click on button');
   });
@@ -215,7 +215,7 @@ test.describe('User Interaction Recording', () => {
         payload: {
           type: 'click',
           limit: 2,
-        }
+        },
       });
     });
 


### PR DESCRIPTION
# fix: resolve lint issues in test files

## Summary

Fixed 67 lint errors across 19 test files that were being masked by a faulty workspace lint configuration. The workspace-level `pnpm lint` command was erroneously always exiting with code 0, hiding actual lint failures in the test directory.

**Key Changes:**
- **Auto-fixed formatting issues**: Import sorting, trailing commas, line breaks, indentation (18 files)
- **Manual security fixes**: Replaced 3 `eval()` calls with direct JavaScript execution 
- **Performance improvement**: Changed `forEach` to `for...of` loop in network-tool.spec.ts
- **Style consistency**: Fixed quote usage (double → single quotes) throughout test files

**Files Modified:** 18 test files (858 insertions, 580 deletions)

## Review & Testing Checklist for Human

- [ ] **Run the test suite** (`pnpm test`) to verify all tests still pass after lint fixes
- [ ] **Review eval() replacements** in mcp-tools.spec.ts (lines 273, 279, 285) - ensure functional equivalence
- [ ] **Verify lint command now works** - run `pnpm exec biome check test/` to confirm it properly reports status
- [ ] **Spot check formatting changes** in a few test files to ensure no logic was accidentally broken

**Test Plan:** Run `pnpm build && pnpm lint && pnpm test` to verify the full development workflow now works correctly.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    BiomeConfig["biome.json<br/>(lint config)"]:::context
    WorkspacePackage["package.json<br/>(workspace lint cmd)"]:::context
    
    MCP["test/mcp-tools.spec.ts<br/>(eval fixes)"]:::major-edit
    Network["test/network-tool.spec.ts<br/>(forEach fix)"]:::major-edit
    Other18["16 other test files<br/>(formatting fixes)"]:::minor-edit
    
    BiomeConfig -.->|"configures rules"| MCP
    BiomeConfig -.->|"configures rules"| Network
    BiomeConfig -.->|"configures rules"| Other18
    
    WorkspacePackage -->|"pnpm lint (was broken)"| BiomeConfig
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Root cause**: The workspace lint script `pnpm -r lint` was not properly propagating exit codes, masking test file lint failures
- **Biome version**: 1.9.4 with recommended rules, 2-space indentation, single quotes
- **Security improvement**: Removed unsafe `eval()` usage in favor of direct DOM API calls
- **Performance**: Replaced `forEach` with `for...of` as recommended by complexity/noForEach rule


**Link to Devin run**: https://app.devin.ai/sessions/bc9d956083514ec9829e0e7999877a54  
**Requested by**: Ramon (@semistrict)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Snapshot tool now clearly reports an error for invalid CSS selectors.

- Bug Fixes
  - Selecting options updates the UI more reliably.
  - JavaScript execution is safer by avoiding eval-based access.
  - Improved robustness when scanning events and parsing network entries (e.g., safer property access).
  - Minor reliability improvements across console/log handling and React DevTools debugging flows.

- Style
  - Consistent formatting, import ordering, and multiline object styles for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->